### PR TITLE
Don't change laser.vector if reflected value undefined

### DIFF
--- a/docs/demos/lasers/demo.js
+++ b/docs/demos/lasers/demo.js
@@ -67,7 +67,10 @@ function advanceTheLaser(laser) {
 
   if (wallsCollidedWith.length !== 0) {
     wallsCollidedWith.forEach(wallCollidedWith => {
-      laser.vector = reflections[wallCollidedWith][laser.vector];
+      // If we've just created a new laser on a boundary cell, this might not be true.
+      if (laser.vector in reflections[wallCollidedWith]) {
+        laser.vector = reflections[wallCollidedWith][laser.vector];
+      }
     });
   }
 


### PR DESCRIPTION
This could happen if a new laser is added by clicking on a boundary cell. In that case the reflection detection will consider that the direction of the laser should be reflected, but in 50% of cases it's already pointing away from the boundary and doesn't need to be.

This fixes a bug whereby the lasers get 'stuck' as a single cell on the boundary in those cases.