### PR TITLE
fix: bad apple demo

### DIFF
--- a/docs/demos/bad-apple/demo.js
+++ b/docs/demos/bad-apple/demo.js
@@ -3,10 +3,25 @@ import { Checkboxland } from '../../../src/index.js';
 const width = 68;
 const height = 51;
 const dimensions = `${width}x${height}`;
+let cbl = undefined;
 
-const cbl = new Checkboxland({ dimensions });
+function init(existingCbl) {
+  cbl = !!existingCbl ? existingCbl : new Checkboxland({ dimensions });
 
-// Original source video: https://archive.org/details/TouhouBadApple
-const videoEl = document.querySelector('video');
+  // Original source video: https://archive.org/details/TouhouBadApple
+  const videoEl = document.querySelector('video');
 
-cbl.renderVideo(videoEl);
+  cbl.renderVideo(videoEl);
+
+  return cbl
+}
+
+function cleanUp() {
+  cbl.renderVideo.cleanUp()
+}
+
+export {
+  init,
+  cleanUp,
+  dimensions,
+}

--- a/docs/demos/bad-apple/index.html
+++ b/docs/demos/bad-apple/index.html
@@ -45,7 +45,10 @@
   <footer>
     <div><a href="../../../">← Back to Checkboxland</div></a>
   </footer>
-  <script type="module" src="demo.js"></script>
+  <script type="module">
+    import * as videoDemo from './demo.js';
+    videoDemo.init();
+  </script>
 </body>
 
 </html>

--- a/docs/demos/video/demo.js
+++ b/docs/demos/video/demo.js
@@ -22,8 +22,13 @@ function init(existingCbl) {
   return cbl;
 }
 
+function cleanUp() {
+  cbl.renderVideo.cleanUp()
+}
+
 export {
   init,
+  cleanUp,
   dimensions
 }
 


### PR DESCRIPTION
There was an error caused by first clicking on the bad apple demo and then on anything else.
```
checkboxland.js:4 Uncaught TypeError: Cannot read properties of undefined (reading 'children')
    at Checkboxland.setCheckboxValue (checkboxland.js:4:238)
    at Checkboxland.setData (checkboxland.js:8:762)
    at renderMediaAsCheckboxes (renderMediaAsCheckboxes.js:3:502)
    at setVideoRenderLoop (renderVideo.js:3:64)
    at renderVideo.js:3:159
```